### PR TITLE
SLING-7197 Completed Scheduled Jobs are not getting fetched.

### DIFF
--- a/src/main/java/org/apache/sling/event/impl/jobs/scheduling/ScheduledJobHandler.java
+++ b/src/main/java/org/apache/sling/event/impl/jobs/scheduling/ScheduledJobHandler.java
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
@@ -295,6 +296,7 @@ public class ScheduledJobHandler implements Runnable {
         properties.remove(ResourceResolver.PROPERTY_RESOURCE_TYPE);
         properties.remove(Job.PROPERTY_JOB_CREATED);
         properties.remove(Job.PROPERTY_JOB_CREATED_INSTANCE);
+        properties.remove(JcrConstants.JCR_PRIMARYTYPE);
 
         final String jobTopic = (String) properties.remove(ResourceHelper.PROPERTY_JOB_TOPIC);
         final String schedulerName = (String) properties.remove(ResourceHelper.PROPERTY_SCHEDULE_NAME);


### PR DESCRIPTION
Scheduled job stored in /var/eventing/scheduled-jobs has node type slingevent:TimedEvent. When scheduled job is processed on time scheduled, a sling job is created using JobManager API and scheduled job node is deleted. Currently, sling job created is of the same type as scheduled job i.e. slingevent:TimedEvent. So deleting node type property from job properties sent to JobManager API while creating Sling Job.