### PR TITLE
Fix json output in correct format

### DIFF
--- a/src/main/java/org/apache/sling/event/impl/jobs/console/InventoryPlugin.java
+++ b/src/main/java/org/apache/sling/event/impl/jobs/console/InventoryPlugin.java
@@ -35,7 +35,6 @@ import org.apache.sling.discovery.InstanceDescription;
 import org.apache.sling.event.impl.jobs.JobConsumerManager;
 import org.apache.sling.event.impl.jobs.config.InternalQueueConfiguration;
 import org.apache.sling.event.impl.jobs.config.JobManagerConfiguration;
-import org.apache.sling.event.impl.jobs.config.QueueConfigurationManager;
 import org.apache.sling.event.impl.jobs.config.TopologyCapabilities;
 import org.apache.sling.event.jobs.JobManager;
 import org.apache.sling.event.jobs.Queue;
@@ -442,7 +441,7 @@ public class InventoryPlugin implements InventoryPrinter {
             pw.printf("      \"stateInfo\" : \"%s\",%n", q.getStateInfo());
             pw.println("      \"configuration\" : {");
             pw.printf("        \"type\" : \"%s\",%n", c.getType());
-            pw.printf("        \"topics\" : \"%s\",%n", formatArrayAsJson(c.getTopics()));
+            pw.printf("        \"topics\" : %s,%n", formatArrayAsJson(c.getTopics()));
             pw.printf("        \"maxParallel\" : %s,%n", c.getMaxParallel());
             pw.printf("        \"maxRetries\" : %s,%n", c.getMaxRetries());
             pw.printf("        \"retryDelayInMs\" : %s,%n", c.getRetryDelayInMs());

--- a/src/test/java/org/apache/sling/event/impl/jobs/console/InventoryPluginTest.java
+++ b/src/test/java/org/apache/sling/event/impl/jobs/console/InventoryPluginTest.java
@@ -48,9 +48,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class InventoryPluginTest extends JsonTestBase {
@@ -88,6 +87,7 @@ public class InventoryPluginTest extends JsonTestBase {
 
         QueueConfiguration mockConfiguration = Mockito.mock(QueueConfiguration.class);
         Mockito.when(mockConfiguration.getType()).thenReturn(QueueConfiguration.Type.ORDERED);
+        Mockito.when(mockConfiguration.getTopics()).thenReturn(new String[]{"topic-1", "topic-2"});
         Mockito.when(mockQueue.getConfiguration()).thenReturn(mockConfiguration);
         Mockito.when(jobManager.getQueues()).thenReturn(new ArrayList<>(Arrays.asList(mockQueue)));
 
@@ -187,7 +187,7 @@ public class InventoryPluginTest extends JsonTestBase {
                 put("$.queues[0].statistics.averageWaitingTime", 0);
                 put("$.queues[0].configuration", null);
                 put("$.queues[0].configuration.type", "ORDERED");
-                put("$.queues[0].configuration.topics", "[]");
+                put("$.queues[0].configuration.topics", new String[]{"topic-1", "topic-2"});
                 put("$.queues[0].configuration.maxParallel", 0);
                 put("$.queues[0].configuration.maxRetries", 0);
                 put("$.queues[0].configuration.retryDelayInMs", 0);
@@ -217,7 +217,13 @@ public class InventoryPluginTest extends JsonTestBase {
 
             expectedJsonPaths.forEach((k, v) -> {
                 if (v != null) {
-                    assertThat(json, hasJsonPath(k, equalTo(v)));
+                    if (v instanceof String[]) {
+                        for (String val : (String[]) v) {
+                            assertThat(json, isJson(withJsonPath(k, hasItem(val))));
+                        }
+                    } else {
+                        assertThat(json, hasJsonPath(k, equalTo(v)));
+                    }
                 } else {
                     assertThat(json, hasJsonPath(k));
                 }


### PR DESCRIPTION
Currently we are producing a wrong json format
```
{
"queues": [
  {
    "configuration" :
      {
        "topics" : "["ref-updater/references", "ref-updater/update", "ref-updater/delete"]"
      }
  }
]
}
```
with the current changes it will produce
```
{
"queues": [
  {
    "configuration" :
      {
        "topics" : ["ref-updater/references", "ref-updater/update", "ref-updater/delete"]
      }
  }
]
}
```
[SLING-11167](https://issues.apache.org/jira/browse/SLING-11167)