### PR TITLE
SLING-11379 do not register the same job over and over

### DIFF
--- a/src/main/java/org/apache/sling/event/impl/jobs/JobBuilderImpl.java
+++ b/src/main/java/org/apache/sling/event/impl/jobs/JobBuilderImpl.java
@@ -64,7 +64,7 @@ public class JobBuilderImpl implements JobBuilder {
         return new JobScheduleBuilderImpl(
                 this.topic,
                 this.properties,
-                UUID.randomUUID().toString(),
+                null, // correct value is calculated later
                 this.jobManager.getJobScheduler());
     }
 }

--- a/src/main/java/org/apache/sling/event/impl/jobs/scheduling/JobScheduleBuilderImpl.java
+++ b/src/main/java/org/apache/sling/event/impl/jobs/scheduling/JobScheduleBuilderImpl.java
@@ -19,18 +19,23 @@
 package org.apache.sling.event.impl.jobs.scheduling;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.sling.event.impl.support.ScheduleInfoImpl;
 import org.apache.sling.event.jobs.JobBuilder.ScheduleBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.event.jobs.ScheduledJobInfo;
 
 /**
  * The builder implementation for scheduled jobs.
  */
 public final class JobScheduleBuilderImpl implements ScheduleBuilder {
+    
+    private static final Logger logger = LoggerFactory.getLogger(JobScheduleBuilderImpl.class);
 
     private final String topic;
 
@@ -104,9 +109,13 @@ public final class JobScheduleBuilderImpl implements ScheduleBuilder {
 
     @Override
     public ScheduledJobInfo add(final List<String> errors) {
+        String finalScheduleName = scheduleName;
+        if (scheduleName == null) {
+            finalScheduleName = deriveScheduleName();
+        }
         return this.jobScheduler.addScheduledJob(topic,
                 properties,
-                scheduleName,
+                finalScheduleName,
                 suspend,
                 schedules,
                 errors);
@@ -116,5 +125,32 @@ public final class JobScheduleBuilderImpl implements ScheduleBuilder {
     public ScheduleBuilder suspend() {
         this.suspend = true;
         return this;
+    }
+
+    /**
+     * In case a scheduleName was not provided we calculate on based on the available
+     * data so we can detect duplicates.
+     * @return a value which is identical for identical jobs
+     */
+    private String deriveScheduleName() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("topic="+topic)
+            .append(",suspend=" + suspend)
+            .append(",");
+
+        if (properties != null) {
+            // sort the properties and flatten them into a string
+            List<String> keys = new ArrayList<>(properties.keySet());
+            Collections.sort(keys);
+            for (String key: keys) {
+                sb.append(key).append("=").append(properties.get(key)).append(",");
+            }
+        }
+        // append all schedules
+        sb.append("schedules=").append(schedules);
+
+        String hashCode = new String("" + sb.toString().hashCode());
+        logger.debug("calculated hash [{}] for unspecified scheduleName, calculated as {}",hashCode, sb.toString());
+        return hashCode;
     }
 }

--- a/src/test/java/org/apache/sling/event/it/SchedulingIT.java
+++ b/src/test/java/org/apache/sling/event/it/SchedulingIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.event.it;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,6 +78,9 @@ public class SchedulingIT extends AbstractJobHandlingIT {
         assertNotNull(info2);
         final ScheduledJobInfo info3 = jobManager.createJob(TOPIC).schedule().weekly(3, 19, 12).add();
         assertNotNull(info3);
+        // This is a duplicate and won't be scheduled, as it is identical to the 3rd job
+        final ScheduledJobInfo info4 = jobManager.createJob(TOPIC).schedule().weekly(3, 19, 12).add();
+        assertNotNull(info4);
 
         assertEquals(3, jobManager.getScheduledJobs().size()); // scheduled jobs
         info3.unschedule();
@@ -106,7 +110,9 @@ public class SchedulingIT extends AbstractJobHandlingIT {
         });
         for(int i=0; i<NUM_ITERATIONS; i++) {
             logger.info("schedulingLoadTest: loop-" + i);
-            jobManager.createJob(ownTopic).schedule().at(new Date(System.currentTimeMillis() + 2500)).add();
+            jobManager.createJob(ownTopic)
+                .properties(Collections.singletonMap("prop", i))
+                .schedule().at(new Date(System.currentTimeMillis() + 2500)).add();
             Thread.sleep(1);
         }
         logger.info("schedulingLoadTest: done, letting jobs be triggered, currently at {} jobs, {} schedules", counter.get(), jobManager.getScheduledJobs().size());


### PR DESCRIPTION
When using the suggested approach in the Sling documentation (https://sling.apache.org/documentation/bundles/apache-sling-eventing-and-job-handling.html#scheduled-jobs-1) the ```scheduleName``` is a random value. If on an OSGI component's activation a scheduledjob is registered that (and never unscheduled, because it's not documented, that you have to), you are registering a new scheduled job with each startup of this component.

To avoid this situation, instead of selecting a random value a ```scheduleName``` with the value ``` null```  is provided. In this case the ```scheduleName``` is derived from the topic, the job properties and the schedule(s); that means that if this approach is used to register a scheduled job, it will be automatically deduplicated, and it's not possible anymore to register the very same job twice.



